### PR TITLE
Update risksem.tex

### DIFF
--- a/risksem/risksem.tex
+++ b/risksem/risksem.tex
@@ -148,13 +148,17 @@ Omfattningen bör vara maximalt 500 ord.
 Genomförandet av seminariet består av tre delar motsvarande delarna 
 i utvecklingen av klassificeringsmodellen.
 
+Senast dagen innan seminariet ska du ha lämnat in en presentation i
+form utav 1-5 bilder innehållandes din klassificeringsmodell, hur du valt
+att klassicera dina informationstillgångar, samt vilka interna och legala krav
+du utgått ifrån för respektive informationstillgång. Räkna med att du får max 5
+minuter att presentera ditt arbete.
+
 \subsection{Redovisning av klassificeringsmodell}
 \label{sec:present}
 
 En till tre personer i respektive grupp kommer att få förmånen att presentera 
-sin utvecklade klassificeringsmodell.
-Förbered en kort presentation om cirka två minuter, då är du beredd utifall att 
-du blir en av de utvalda.
+sitt arbete.
 
 \subsection{Användning av klassificeringsmodell}
 \label{sec:use}
@@ -163,7 +167,7 @@ Några nya informationstillgångar kommer att ges under seminariet.
 Ni kommer att delas upp i mindre grupper, där ni inom grupperna diskuterar er 
 fram till vart ni vill placera dessa informationstillgångar i en utvald 
 klassificeringsmodell.
-Varje grupp presenterar därefter sitt förslag med tillhörande motivering.
+Utvalda grupper presenterar därefter sitt förslag med tillhörande motivering.
 
 \subsection{Riskanalys}
 \label{sec:risk}
@@ -171,10 +175,10 @@ Varje grupp presenterar därefter sitt förslag med tillhörande motivering.
 I samma grupper som ni jobbade med under \cref{sec:use}, ska ni nu utföra en 
 riskanalys på en informationstillgång som seminarieledaren ger er.
 Varje grupp ska komma fram till minst fem (5) hot mot vald 
-informationstillgång.
-Varje grupp ska presentera sina resultat inför klassen genom att placera ut 
-sina hot i en konsekvens- och sannolikhetsmatris med tillhörande motivering.
-
+informationstillgång som ska placeras i en riskmatris, samt ska ni för upptäckt
+hot komma fram till ett åtgärdsförslag. Varje grupp ska sedan inför helklass presentera
+de två hot som de anser vara mest kritiska. Detta ska övervägas genom att vikta sannolikheten
+att hotet förekommer gentemot uppskattad frekvens.
 
 \section{Examination}
 \label{sec:examination}
@@ -236,6 +240,7 @@ PM:et ska innehålla uppgifterna från \cref{sec:work}:
 
 Dokumentet ska vara skrivet med akademisk svenska eller engelska och ha 
 korrekta referenser.
+
 Aktivt deltagande i seminariet krävs för godkänt betyg.
 
 


### PR DESCRIPTION
Uppdaterade information om förberedelse inför seminariet, lade till krav på inlämnad presentation senast dagen före seminarie. Gjorde även några mindre förändringar rörandes genomförandet. Exempelvis behöver inte alla presentera deras resultat av klassificeringsarbetet, utan exempelvis tre av fem grupper presenterar och övriga två grupper måste komma med tillägg.
